### PR TITLE
Add store_attachments DSL for persisting user input files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /spec/reports/
 /tmp/
 /spec/dummy/log/
+/spec/dummy/tmp/
 
 # rspec failure tracking
 .rspec_status

--- a/app/models/ruby_llm/agents/execution_detail.rb
+++ b/app/models/ruby_llm/agents/execution_detail.rb
@@ -14,6 +14,8 @@ module RubyLLM
 
       belongs_to :execution, class_name: "RubyLLM::Agents::Execution"
 
+      has_many_attached :user_attachments
+
       validates :execution_id, presence: true
     end
   end

--- a/app/views/ruby_llm/agents/executions/_user_attachments.html.erb
+++ b/app/views/ruby_llm/agents/executions/_user_attachments.html.erb
@@ -1,0 +1,30 @@
+<% attachments = @execution.detail&.user_attachments %>
+<% if attachments.present? && attachments.any? %>
+<div class="flex items-center gap-3 mt-6 mb-3">
+  <span class="text-[10px] font-medium text-gray-400 dark:text-gray-600 uppercase tracking-widest font-mono">user attachments (<%= attachments.size %>)</span>
+  <div class="flex-1 border-t border-gray-200 dark:border-gray-800"></div>
+</div>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-3">
+  <% attachments.each do |attachment| %>
+    <div class="border border-gray-200 dark:border-gray-800 rounded p-3 flex flex-col gap-2">
+      <% if attachment.image? %>
+        <%= image_tag(main_app.url_for(attachment), class: "w-full h-32 object-contain bg-gray-50 dark:bg-gray-900 rounded") %>
+      <% elsif attachment.content_type == "application/pdf" %>
+        <div class="w-full h-32 bg-gray-50 dark:bg-gray-900 rounded flex items-center justify-center">
+          <span class="font-mono text-xs text-gray-500 dark:text-gray-400">PDF</span>
+        </div>
+      <% else %>
+        <div class="w-full h-32 bg-gray-50 dark:bg-gray-900 rounded flex items-center justify-center">
+          <span class="font-mono text-xs text-gray-500 dark:text-gray-400"><%= attachment.content_type&.split("/")&.last || "file" %></span>
+        </div>
+      <% end %>
+      <div class="flex flex-col gap-0.5 font-mono text-xs">
+        <span class="text-gray-800 dark:text-gray-200 truncate" title="<%= attachment.filename %>"><%= attachment.filename %></span>
+        <span class="text-gray-400 dark:text-gray-600"><%= number_to_human_size(attachment.byte_size) %> &middot; <%= attachment.content_type %></span>
+        <%= link_to "download", main_app.url_for(attachment), class: "text-blue-600 dark:text-blue-400 hover:underline", target: "_blank", rel: "noopener" %>
+      </div>
+    </div>
+  <% end %>
+</div>
+<% end %>

--- a/app/views/ruby_llm/agents/executions/show.html.erb
+++ b/app/views/ruby_llm/agents/executions/show.html.erb
@@ -75,6 +75,9 @@
   <%= render "ruby_llm/agents/executions/audio_player" %>
 <% end %>
 
+<!-- ── user attachments ──────────────── -->
+<%= render "ruby_llm/agents/executions/user_attachments" %>
+
 <!-- ── tokens ──────────────────────── -->
 <%
   input_tokens = @execution.input_tokens || 0

--- a/lib/ruby_llm/agents/base_agent.rb
+++ b/lib/ruby_llm/agents/base_agent.rb
@@ -48,6 +48,7 @@ module RubyLLM
       extend DSL::Caching
       extend DSL::Queryable
       extend DSL::Knowledge
+      extend DSL::Attachments
       include DSL::Knowledge::InstanceMethods
       include CacheHelper
 

--- a/lib/ruby_llm/agents/dsl.rb
+++ b/lib/ruby_llm/agents/dsl.rb
@@ -5,6 +5,7 @@ require_relative "dsl/reliability"
 require_relative "dsl/caching"
 require_relative "dsl/queryable"
 require_relative "dsl/knowledge"
+require_relative "dsl/attachments"
 
 module RubyLLM
   module Agents

--- a/lib/ruby_llm/agents/dsl/attachments.rb
+++ b/lib/ruby_llm/agents/dsl/attachments.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Agents
+    module DSL
+      # DSL for persisting user-supplied input attachments alongside an
+      # execution record, so the original files can be inspected later from
+      # the dashboard.
+      #
+      # Opt-in per agent. When enabled, any files passed via the `with:`
+      # keyword to `.call` are attached to the Execution's detail record.
+      #
+      # @example Enable with the Active Storage backend
+      #   class DiagramImportAgent < ApplicationAgent
+      #     store_attachments :active_storage
+      #   end
+      #
+      #   DiagramImportAgent.call(with: "path/to/diagram.png")
+      #   # => The file is attached to execution.detail.user_attachments
+      #
+      # Only `:active_storage` is supported. Agents that do not declare
+      # `store_attachments` are unchanged — `with:` continues to work as
+      # before, just without persistence.
+      module Attachments
+        SUPPORTED_BACKENDS = %i[active_storage].freeze
+
+        # Sets or returns the attachment storage backend for this agent.
+        #
+        # @param backend [Symbol, nil] `:active_storage` or nil to read the current value
+        # @return [Symbol, nil] The configured backend, or nil if disabled
+        # @raise [ArgumentError] If an unsupported backend is given
+        def store_attachments(backend = nil)
+          if backend
+            unless SUPPORTED_BACKENDS.include?(backend)
+              raise ArgumentError,
+                "Unsupported store_attachments backend #{backend.inspect}. Supported: #{SUPPORTED_BACKENDS.inspect}"
+            end
+
+            @store_attachments = backend
+          end
+
+          return @store_attachments if defined?(@store_attachments) && !@store_attachments.nil?
+
+          inherited_store_attachments
+        end
+
+        # Whether any attachment persistence is enabled on this agent.
+        #
+        # @return [Boolean]
+        def store_attachments_enabled?
+          !store_attachments.nil?
+        end
+
+        private
+
+        def inherited_store_attachments
+          return nil unless superclass.respond_to?(:store_attachments)
+
+          superclass.store_attachments
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/agents/pipeline.rb
+++ b/lib/ruby_llm/agents/pipeline.rb
@@ -36,6 +36,7 @@ require_relative "pipeline/middleware/budget"
 require_relative "pipeline/middleware/cache"
 require_relative "pipeline/middleware/instrumentation"
 require_relative "pipeline/middleware/reliability"
+require_relative "pipeline/middleware/attachment_persistence"
 
 module RubyLLM
   module Agents

--- a/lib/ruby_llm/agents/pipeline/builder.rb
+++ b/lib/ruby_llm/agents/pipeline/builder.rb
@@ -139,6 +139,10 @@ module RubyLLM
               # Instrumentation (always - for tracking, must be before Cache)
               builder.use(Middleware::Instrumentation)
 
+              # Attachment persistence (if agent opts in via store_attachments)
+              # Runs after Instrumentation so execution_id is available.
+              builder.use(Middleware::AttachmentPersistence) if attachments_enabled?(agent_class)
+
               # Caching (if enabled on the agent)
               builder.use(Middleware::Cache) if cache_enabled?(agent_class)
 
@@ -211,6 +215,18 @@ module RubyLLM
             RubyLLM::Agents.configuration.budgets_enabled?
           rescue => e
             Rails.logger.debug("[RubyLLM::Agents::Pipeline] Failed to check budgets_enabled: #{e.message}") if defined?(Rails) && Rails.logger
+            false
+          end
+
+          # Check if attachment persistence is enabled for an agent
+          #
+          # @param agent_class [Class] The agent class
+          # @return [Boolean]
+          def attachments_enabled?(agent_class)
+            return false unless agent_class
+
+            agent_class.respond_to?(:store_attachments_enabled?) && agent_class.store_attachments_enabled?
+          rescue
             false
           end
 

--- a/lib/ruby_llm/agents/pipeline/middleware/attachment_persistence.rb
+++ b/lib/ruby_llm/agents/pipeline/middleware/attachment_persistence.rb
@@ -48,8 +48,17 @@ module RubyLLM
             error("Failed to persist user attachments: #{e.message}", context)
           end
 
+          # Reads the caller's `with:` argument from the context.
+          #
+          # BaseAgent#build_context nests the raw `with:` value under
+          # `context.options[:options][:attachments]` (see
+          # BaseAgent#execution_options). We look there, and also fall back
+          # to `context.options[:with]` for any caller that builds a
+          # Context directly.
           def attachment_inputs(context)
-            Array(context.options[:with]).compact
+            nested = context.options.dig(:options, :attachments)
+            direct = context.options[:with]
+            Array(nested || direct).compact
           end
 
           def attach(detail, input)

--- a/lib/ruby_llm/agents/pipeline/middleware/attachment_persistence.rb
+++ b/lib/ruby_llm/agents/pipeline/middleware/attachment_persistence.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module Agents
+    module Pipeline
+      module Middleware
+        # Persists input attachments (files passed via `with:`) to the
+        # execution's detail record using the configured storage backend.
+        #
+        # Activates when the agent opts in with `store_attachments :active_storage`
+        # and the call includes a `with:` argument. Runs after Instrumentation
+        # so an Execution record already exists.
+        #
+        # Attachment is performed after the downstream call succeeds. On
+        # failure, attachments are not persisted (keeps the dashboard
+        # record focused on what the LLM actually saw for a completed run).
+        # Any error during attachment is logged and swallowed so it never
+        # breaks the agent call.
+        class AttachmentPersistence < Base
+          def call(context)
+            result = @app.call(context)
+            persist_attachments(context) if should_persist?(context)
+            result
+          end
+
+          private
+
+          def should_persist?(context)
+            return false unless @agent_class.respond_to?(:store_attachments_enabled?)
+            return false unless @agent_class.store_attachments_enabled?
+            return false unless @agent_class.store_attachments == :active_storage
+            return false if context.failed?
+            return false if context.execution_id.nil?
+
+            attachment_inputs(context).any?
+          end
+
+          def persist_attachments(context)
+            execution = RubyLLM::Agents::Execution.find_by(id: context.execution_id)
+            return unless execution
+
+            detail = execution.detail || execution.create_detail!
+
+            attachment_inputs(context).each do |input|
+              attach(detail, input)
+            end
+          rescue => e
+            error("Failed to persist user attachments: #{e.message}", context)
+          end
+
+          def attachment_inputs(context)
+            Array(context.options[:with]).compact
+          end
+
+          def attach(detail, input)
+            payload = build_attachment_payload(input)
+            return unless payload
+
+            detail.user_attachments.attach(payload)
+          end
+
+          # Normalises a `with:` entry into a Hash suitable for
+          # ActiveStorage::Attached#attach, handling the common input types.
+          #
+          # Skips URLs (strings that parse as http/https) since they are not
+          # local files — the LLM fetches them directly.
+          def build_attachment_payload(input)
+            case input
+            when String
+              return nil if url?(input)
+
+              file_payload(input)
+            when Pathname
+              file_payload(input.to_s)
+            when File, Tempfile
+              {io: File.open(input.path), filename: File.basename(input.path), content_type: detect_content_type(input.path)}
+            else
+              return input if uploaded_file?(input)
+
+              nil
+            end
+          end
+
+          def file_payload(path)
+            return nil unless File.exist?(path)
+
+            {io: File.open(path), filename: File.basename(path), content_type: detect_content_type(path)}
+          end
+
+          def uploaded_file?(input)
+            defined?(ActionDispatch::Http::UploadedFile) && input.is_a?(ActionDispatch::Http::UploadedFile)
+          end
+
+          def url?(string)
+            string.start_with?("http://", "https://")
+          end
+
+          def detect_content_type(path)
+            Marcel::MimeType.for(Pathname.new(path))
+          rescue
+            "application/octet-stream"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/agents/store_attachments_integration_spec.rb
+++ b/spec/agents/store_attachments_integration_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# End-to-end spec for `store_attachments :active_storage`.
+#
+# This exercises the full BaseAgent.call → pipeline → attachment flow so
+# that a rename of the key BaseAgent#execution_options uses to forward
+# `with:` into the context (or any other break in that contract) is
+# caught, not silently no-op'd the way earlier middleware-only specs
+# allowed.
+RSpec.describe "Store attachments integration" do
+  let(:file_path) { File.join(Dir.tmpdir, "store_attachments_integration_spec_#{SecureRandom.hex(4)}.txt") }
+
+  before do
+    File.write(file_path, "diagram content")
+
+    RubyLLM::Agents.reset_configuration!
+    config = RubyLLM::Agents.configuration
+    config.track_executions = true
+    config.persist_prompts = true
+    config.persist_responses = false
+
+    stub_agent_configuration
+    response = build_real_response(content: "ok", input_tokens: 10, output_tokens: 5)
+    stub_ruby_llm_chat(build_mock_chat_client(response: response))
+  end
+
+  after do
+    File.delete(file_path) if File.exist?(file_path)
+  end
+
+  let(:enabled_agent_class) do
+    Class.new(RubyLLM::Agents::Base) do
+      def self.name
+        "EnabledAttachmentsAgent"
+      end
+
+      model "gpt-4o"
+      system "You are a test agent."
+      user "Process: {query}"
+      param :query, required: true
+
+      store_attachments :active_storage
+    end
+  end
+
+  let(:disabled_agent_class) do
+    Class.new(RubyLLM::Agents::Base) do
+      def self.name
+        "DisabledAttachmentsAgent"
+      end
+
+      model "gpt-4o"
+      system "You are a test agent."
+      user "Process: {query}"
+      param :query, required: true
+    end
+  end
+
+  it "attaches the file passed via with: onto the execution's detail" do
+    enabled_agent_class.call(query: "hello", with: file_path)
+
+    execution = RubyLLM::Agents::Execution.last
+    expect(execution).to be_present
+    expect(execution.status).to eq("success")
+
+    detail = execution.detail
+    expect(detail).to be_present
+    expect(detail.user_attachments.count).to eq(1)
+    expect(detail.user_attachments.first.filename.to_s).to eq(File.basename(file_path))
+  end
+
+  it "does not attach when store_attachments is not declared" do
+    disabled_agent_class.call(query: "hello", with: file_path)
+
+    execution = RubyLLM::Agents::Execution.last
+    expect(execution.detail&.user_attachments&.count.to_i).to eq(0)
+  end
+
+  it "does not attach when with: is omitted" do
+    enabled_agent_class.call(query: "hello")
+
+    execution = RubyLLM::Agents::Execution.last
+    expect(execution.detail&.user_attachments&.count.to_i).to eq(0)
+  end
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -5,6 +5,7 @@ require_relative "boot"
 require "rails"
 require "active_model/railtie"
 require "active_record/railtie"
+require "active_storage/engine"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "active_job/railtie"
@@ -28,5 +29,11 @@ module Dummy
     config.active_record.encryption.primary_key = "test-primary-key-that-is-at-least-32-bytes-long"
     config.active_record.encryption.deterministic_key = "test-deterministic-key-32-bytes!"
     config.active_record.encryption.key_derivation_salt = "test-key-derivation-salt-value!"
+
+    # Active Storage uses an in-memory test service
+    config.active_storage.service = :test
+    config.active_storage.service_configurations = {
+      "test" => {"service" => "Disk", "root" => Rails.root.join("tmp/storage").to_s}
+    }
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -202,4 +202,33 @@ ActiveRecord::Schema.define do
   end
 
   add_index :ruby_llm_agents_overrides, :agent_type, unique: true
+
+  # Active Storage tables (for has_many_attached :user_attachments on ExecutionDetail)
+  create_table :active_storage_blobs, force: :cascade do |t|
+    t.string :key, null: false
+    t.string :filename, null: false
+    t.string :content_type
+    t.text :metadata
+    t.string :service_name, null: false
+    t.bigint :byte_size, null: false
+    t.string :checksum
+    t.datetime :created_at, null: false
+  end
+  add_index :active_storage_blobs, :key, unique: true
+
+  create_table :active_storage_attachments, force: :cascade do |t|
+    t.string :name, null: false
+    t.references :record, null: false, polymorphic: true, index: false
+    t.references :blob, null: false
+    t.datetime :created_at, null: false
+  end
+  add_index :active_storage_attachments, [:record_type, :record_id, :name, :blob_id],
+    name: "index_active_storage_attachments_uniqueness", unique: true
+
+  create_table :active_storage_variant_records, force: :cascade do |t|
+    t.references :blob, null: false
+    t.string :variation_digest, null: false
+  end
+  add_index :active_storage_variant_records, [:blob_id, :variation_digest],
+    name: "index_active_storage_variant_records_uniqueness", unique: true
 end

--- a/spec/lib/dsl/attachments_spec.rb
+++ b/spec/lib/dsl/attachments_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubyLLM::Agents::DSL::Attachments do
+  let(:test_class) do
+    Class.new do
+      extend RubyLLM::Agents::DSL::Attachments
+
+      def self.name
+        "TestAgent"
+      end
+    end
+  end
+
+  describe "#store_attachments" do
+    it "is disabled by default" do
+      expect(test_class.store_attachments).to be_nil
+      expect(test_class.store_attachments_enabled?).to be(false)
+    end
+
+    it "accepts the :active_storage backend" do
+      test_class.store_attachments(:active_storage)
+
+      expect(test_class.store_attachments).to eq(:active_storage)
+      expect(test_class.store_attachments_enabled?).to be(true)
+    end
+
+    it "raises ArgumentError for unsupported backends" do
+      expect {
+        test_class.store_attachments(:redis)
+      }.to raise_error(ArgumentError, /Unsupported store_attachments backend/)
+    end
+
+    it "inherits the setting from the superclass" do
+      parent = Class.new do
+        extend RubyLLM::Agents::DSL::Attachments
+        store_attachments :active_storage
+      end
+      child = Class.new(parent)
+
+      expect(child.store_attachments).to eq(:active_storage)
+      expect(child.store_attachments_enabled?).to be(true)
+    end
+  end
+end

--- a/spec/lib/pipeline/middleware/attachment_persistence_spec.rb
+++ b/spec/lib/pipeline/middleware/attachment_persistence_spec.rb
@@ -44,12 +44,14 @@ RSpec.describe RubyLLM::Agents::Pipeline::Middleware::AttachmentPersistence do
     )
   end
 
-  def build_context(agent_class:, execution_id: nil, with: nil, error: nil)
-    ctx = RubyLLM::Agents::Pipeline::Context.new(
-      input: "test",
-      agent_class: agent_class,
-      with: with
-    )
+  def build_context(agent_class:, execution_id: nil, with: nil, error: nil, nest: false)
+    ctx_args = {input: "test", agent_class: agent_class}
+    if nest
+      ctx_args[:options] = {attachments: with}
+    else
+      ctx_args[:with] = with
+    end
+    ctx = RubyLLM::Agents::Pipeline::Context.new(**ctx_args)
     ctx.execution_id = execution_id
     ctx.error = error
     ctx
@@ -69,6 +71,15 @@ RSpec.describe RubyLLM::Agents::Pipeline::Middleware::AttachmentPersistence do
         expect(detail).not_to be_nil
         expect(detail.user_attachments.count).to eq(1)
         expect(detail.user_attachments.first.filename.to_s).to eq(File.basename(file_path))
+      end
+
+      it "reads the file from execution_options[:attachments] (as BaseAgent nests it)" do
+        execution = build_execution
+        context = build_context(agent_class: enabled_agent_class, execution_id: execution.id, with: file_path, nest: true)
+
+        described_class.new(downstream_app, enabled_agent_class).call(context)
+
+        expect(execution.reload.detail.user_attachments.count).to eq(1)
       end
 
       it "accepts an array of file paths" do

--- a/spec/lib/pipeline/middleware/attachment_persistence_spec.rb
+++ b/spec/lib/pipeline/middleware/attachment_persistence_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubyLLM::Agents::Pipeline::Middleware::AttachmentPersistence do
+  let(:enabled_agent_class) do
+    Class.new do
+      extend RubyLLM::Agents::DSL::Attachments
+      store_attachments :active_storage
+
+      def self.name
+        "EnabledAgent"
+      end
+    end
+  end
+
+  let(:disabled_agent_class) do
+    Class.new do
+      extend RubyLLM::Agents::DSL::Attachments
+
+      def self.name
+        "DisabledAgent"
+      end
+    end
+  end
+
+  let(:file_path) { File.join(Dir.tmpdir, "attachment_persistence_spec_#{SecureRandom.hex(4)}.txt") }
+
+  before do
+    File.write(file_path, "hello world")
+  end
+
+  after do
+    File.delete(file_path) if File.exist?(file_path)
+  end
+
+  def build_execution
+    RubyLLM::Agents::Execution.create!(
+      agent_type: "EnabledAgent",
+      execution_type: "chat",
+      model_id: "test-model",
+      status: "success",
+      started_at: Time.current
+    )
+  end
+
+  def build_context(agent_class:, execution_id: nil, with: nil, error: nil)
+    ctx = RubyLLM::Agents::Pipeline::Context.new(
+      input: "test",
+      agent_class: agent_class,
+      with: with
+    )
+    ctx.execution_id = execution_id
+    ctx.error = error
+    ctx
+  end
+
+  let(:downstream_app) { ->(ctx) { ctx } }
+
+  describe "#call" do
+    context "when the agent enables store_attachments :active_storage" do
+      it "attaches the file at the given path to the execution's detail" do
+        execution = build_execution
+        context = build_context(agent_class: enabled_agent_class, execution_id: execution.id, with: file_path)
+
+        described_class.new(downstream_app, enabled_agent_class).call(context)
+
+        detail = execution.reload.detail
+        expect(detail).not_to be_nil
+        expect(detail.user_attachments.count).to eq(1)
+        expect(detail.user_attachments.first.filename.to_s).to eq(File.basename(file_path))
+      end
+
+      it "accepts an array of file paths" do
+        other_path = File.join(Dir.tmpdir, "attachment_spec_other_#{SecureRandom.hex(4)}.txt")
+        File.write(other_path, "more content")
+        execution = build_execution
+        context = build_context(agent_class: enabled_agent_class, execution_id: execution.id, with: [file_path, other_path])
+
+        described_class.new(downstream_app, enabled_agent_class).call(context)
+
+        expect(execution.reload.detail.user_attachments.count).to eq(2)
+      ensure
+        File.delete(other_path) if other_path && File.exist?(other_path)
+      end
+
+      it "skips URL inputs" do
+        execution = build_execution
+        context = build_context(agent_class: enabled_agent_class, execution_id: execution.id, with: "https://example.com/image.png")
+
+        described_class.new(downstream_app, enabled_agent_class).call(context)
+
+        expect(execution.reload.detail&.user_attachments&.count.to_i).to eq(0)
+      end
+
+      it "does not persist when execution failed" do
+        execution = build_execution
+        context = build_context(
+          agent_class: enabled_agent_class,
+          execution_id: execution.id,
+          with: file_path,
+          error: StandardError.new("boom")
+        )
+
+        described_class.new(downstream_app, enabled_agent_class).call(context)
+
+        expect(execution.reload.detail&.user_attachments&.count.to_i).to eq(0)
+      end
+
+      it "is a no-op when `with:` is missing" do
+        execution = build_execution
+        context = build_context(agent_class: enabled_agent_class, execution_id: execution.id, with: nil)
+
+        described_class.new(downstream_app, enabled_agent_class).call(context)
+
+        expect(execution.reload.detail&.user_attachments&.count.to_i).to eq(0)
+      end
+    end
+
+    context "when the agent does not enable store_attachments" do
+      it "is a no-op even when `with:` is provided" do
+        execution = build_execution
+        context = build_context(agent_class: disabled_agent_class, execution_id: execution.id, with: file_path)
+
+        described_class.new(downstream_app, disabled_agent_class).call(context)
+
+        expect(execution.reload.detail&.user_attachments&.count.to_i).to eq(0)
+      end
+    end
+
+    context "when the downstream app raises" do
+      it "re-raises and does not attach" do
+        execution = build_execution
+        context = build_context(agent_class: enabled_agent_class, execution_id: execution.id, with: file_path)
+        raising_app = ->(_ctx) { raise StandardError, "boom" }
+
+        expect {
+          described_class.new(raising_app, enabled_agent_class).call(context)
+        }.to raise_error(StandardError, "boom")
+
+        expect(execution.reload.detail&.user_attachments&.count.to_i).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/models/ruby_llm/agents/execution_detail_spec.rb
+++ b/spec/models/ruby_llm/agents/execution_detail_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubyLLM::Agents::ExecutionDetail do
+  describe "user_attachments" do
+    it "supports attaching multiple files via Active Storage" do
+      execution = RubyLLM::Agents::Execution.create!(
+        agent_type: "TestAgent",
+        execution_type: "chat",
+        model_id: "test-model",
+        status: "success",
+        started_at: Time.current
+      )
+      detail = execution.create_detail!
+
+      detail.user_attachments.attach(
+        io: StringIO.new("first"),
+        filename: "first.txt",
+        content_type: "text/plain"
+      )
+      detail.user_attachments.attach(
+        io: StringIO.new("second"),
+        filename: "second.txt",
+        content_type: "text/plain"
+      )
+
+      expect(detail.reload.user_attachments.count).to eq(2)
+      expect(detail.user_attachments.map { |a| a.filename.to_s }).to match_array(%w[first.txt second.txt])
+    end
+  end
+end


### PR DESCRIPTION
Introduces an opt-in `store_attachments :active_storage` DSL on agents that persists files passed via `with:` to the execution's detail record using Active Storage (has_many_attached :user_attachments).

Implemented as a dedicated AttachmentPersistence middleware that runs after Instrumentation, so the Execution record already exists when attachments are saved. Agents that don't declare `store_attachments` are unchanged. URLs passed via `with:` are skipped; failed executions do not persist attachments; attachment errors are logged and swallowed so they never break the agent call.

Includes a dashboard partial rendering previews and download links for attached files, and wires Active Storage into the dummy app so the new specs can exercise the attach flow.

Closes adham90/ruby_llm-agents#25