### PR TITLE
Fall back to configured model for cost lookup

### DIFF
--- a/lib/ruby_llm/agents/base_agent.rb
+++ b/lib/ruby_llm/agents/base_agent.rb
@@ -933,14 +933,21 @@ module RubyLLM
         context.total_cost = (context.input_cost + context.output_cost).round(6)
       end
 
-      # Finds model pricing info
+      # Finds model pricing info.
+      #
+      # Providers often return dated model variants (e.g.
+      # "anthropic/claude-4.6-sonnet-20260217") that aren't in the
+      # RubyLLM::Models registry, while the agent is configured with a
+      # stable alias (e.g. "anthropic/claude-sonnet-4.6") that is. When the
+      # response's model_id misses, fall back to the agent's configured
+      # model so cost calculation still finds pricing.
       #
       # @param model_id [String] The model ID
       # @return [Hash, nil] Model info with pricing
       def find_model_info(model_id)
         return nil unless defined?(RubyLLM::Models)
 
-        RubyLLM::Models.find(model_id)
+        RubyLLM::Models.find(model_id) || RubyLLM::Models.find(model)
       rescue
         nil
       end

--- a/lib/ruby_llm/agents/base_agent.rb
+++ b/lib/ruby_llm/agents/base_agent.rb
@@ -914,12 +914,19 @@ module RubyLLM
         calculate_costs(response, context) if context.input_tokens
       end
 
-      # Calculates costs for the response
+      # Calculates costs for the response.
+      #
+      # Providers often return dated model variants (e.g.
+      # "anthropic/claude-4.6-sonnet-20260217") that aren't in the
+      # RubyLLM::Models registry, while the agent is configured with a
+      # stable alias (e.g. "anthropic/claude-sonnet-4.6") that is. When the
+      # response's model_id misses, fall back to the agent's configured
+      # model so cost calculation still finds pricing.
       #
       # @param response [RubyLLM::Message] The response
       # @param context [Pipeline::Context] The context
       def calculate_costs(response, context)
-        model_info = find_model_info(response.model_id || model)
+        model_info = find_model_info(response.model_id) || find_model_info(model)
         return unless model_info
 
         input_tokens = context.input_tokens || 0
@@ -935,19 +942,12 @@ module RubyLLM
 
       # Finds model pricing info.
       #
-      # Providers often return dated model variants (e.g.
-      # "anthropic/claude-4.6-sonnet-20260217") that aren't in the
-      # RubyLLM::Models registry, while the agent is configured with a
-      # stable alias (e.g. "anthropic/claude-sonnet-4.6") that is. When the
-      # response's model_id misses, fall back to the agent's configured
-      # model so cost calculation still finds pricing.
-      #
       # @param model_id [String] The model ID
       # @return [Hash, nil] Model info with pricing
       def find_model_info(model_id)
-        return nil unless defined?(RubyLLM::Models)
+        return nil unless defined?(RubyLLM::Models) && model_id
 
-        RubyLLM::Models.find(model_id) || RubyLLM::Models.find(model)
+        RubyLLM::Models.find(model_id)
       rescue
         nil
       end

--- a/spec/lib/base_agent_execution_spec.rb
+++ b/spec/lib/base_agent_execution_spec.rb
@@ -527,19 +527,28 @@ RSpec.describe RubyLLM::Agents::BaseAgent, "execution methods" do
       end
     end
 
-    context "when model info is not available for either model" do
+    context "when neither the response model_id nor the configured model is registered" do
+      let(:agent) do
+        Class.new(RubyLLM::Agents::BaseAgent) { model "nonexistent-configured-model" }.new
+      end
       let(:response) { build_real_response(model_id: "nonexistent-response-model") }
-
-      before do
-        # Both the response model and the agent's configured model miss the registry.
-        allow(RubyLLM::Models).to receive(:find).with("nonexistent-response-model").and_return(nil)
-        allow(RubyLLM::Models).to receive(:find).with("gpt-4o").and_return(nil)
+      let(:context) do
+        ctx = RubyLLM::Agents::Pipeline::Context.new(
+          input: "test query",
+          agent_class: agent.class,
+          agent_instance: agent,
+          model: "nonexistent-configured-model"
+        )
+        ctx.input_tokens = 1000
+        ctx.output_tokens = 500
+        ctx
       end
 
       it "does not calculate costs" do
+        # Real RubyLLM::Models.find raises ModelNotFoundError for both lookups;
+        # find_model_info rescues each, so costs stay at the default 0.0.
         agent.send(:calculate_costs, response, context)
 
-        # find_model_info returns nil — costs stay at default 0.0
         expect(context.input_cost).to eq(0.0)
         expect(context.output_cost).to eq(0.0)
         expect(context.total_cost).to eq(0.0)
@@ -547,16 +556,12 @@ RSpec.describe RubyLLM::Agents::BaseAgent, "execution methods" do
     end
 
     context "when the response model_id is not registered but the configured model is" do
-      let(:response) { build_real_response(model_id: "anthropic/claude-4.6-sonnet-20260217-dated") }
+      let(:response) { build_real_response(model_id: "gpt-4o-2099-dated-variant") }
       let(:model_info) { RubyLLM::Models.find("gpt-4o") }
 
-      before do
-        # Dated variant returns nil; let the configured-model lookup pass through.
-        allow(RubyLLM::Models).to receive(:find).and_call_original
-        allow(RubyLLM::Models).to receive(:find).with("anthropic/claude-4.6-sonnet-20260217-dated").and_return(nil)
-      end
-
       it "falls back to the agent's configured model and still calculates costs" do
+        # No stubbing — let RubyLLM::Models.find raise for the bogus dated variant
+        # and resolve for real for the configured "gpt-4o".
         agent.send(:calculate_costs, response, context)
 
         expected_input = (1000 / 1_000_000.0) * model_info.pricing.text_tokens.input

--- a/spec/lib/base_agent_execution_spec.rb
+++ b/spec/lib/base_agent_execution_spec.rb
@@ -527,16 +527,44 @@ RSpec.describe RubyLLM::Agents::BaseAgent, "execution methods" do
       end
     end
 
-    context "when model info is not available" do
-      let(:response) { build_real_response(model_id: "nonexistent-model-xyz") }
+    context "when model info is not available for either model" do
+      let(:response) { build_real_response(model_id: "nonexistent-response-model") }
+
+      before do
+        # Both the response model and the agent's configured model miss the registry.
+        allow(RubyLLM::Models).to receive(:find).with("nonexistent-response-model").and_return(nil)
+        allow(RubyLLM::Models).to receive(:find).with("gpt-4o").and_return(nil)
+      end
 
       it "does not calculate costs" do
         agent.send(:calculate_costs, response, context)
 
-        # find_model_info rescues the error and returns nil — costs stay at default 0.0
+        # find_model_info returns nil — costs stay at default 0.0
         expect(context.input_cost).to eq(0.0)
         expect(context.output_cost).to eq(0.0)
         expect(context.total_cost).to eq(0.0)
+      end
+    end
+
+    context "when the response model_id is not registered but the configured model is" do
+      let(:response) { build_real_response(model_id: "anthropic/claude-4.6-sonnet-20260217-dated") }
+      let(:model_info) { RubyLLM::Models.find("gpt-4o") }
+
+      before do
+        # Dated variant returns nil; let the configured-model lookup pass through.
+        allow(RubyLLM::Models).to receive(:find).and_call_original
+        allow(RubyLLM::Models).to receive(:find).with("anthropic/claude-4.6-sonnet-20260217-dated").and_return(nil)
+      end
+
+      it "falls back to the agent's configured model and still calculates costs" do
+        agent.send(:calculate_costs, response, context)
+
+        expected_input = (1000 / 1_000_000.0) * model_info.pricing.text_tokens.input
+        expected_output = (500 / 1_000_000.0) * model_info.pricing.text_tokens.output
+
+        expect(context.input_cost).to be_within(0.0000001).of(expected_input)
+        expect(context.output_cost).to be_within(0.0000001).of(expected_output)
+        expect(context.total_cost).to be > 0
       end
     end
 


### PR DESCRIPTION
Providers often return dated model variants (e.g.
"anthropic/claude-4.6-sonnet-20260217") that aren't in the RubyLLM::Models registry, while apps configure agents with stable aliases (e.g. "anthropic/claude-sonnet-4.6") that are. Previously, a registry miss on the response's model_id resulted in no cost calculation at all — executions recorded $0 spend even though pricing was available for the configured model.

When the response model_id misses, fall back to the agent's configured model before giving up. 

Closes #27.