### PR TITLE
Fix NoMethodError when a tool returns Tool::Halt

### DIFF
--- a/lib/ruby_llm/agents/base_agent.rb
+++ b/lib/ruby_llm/agents/base_agent.rb
@@ -738,6 +738,7 @@ module RubyLLM
       def execute(context)
         @context = context
         client = build_client(context)
+        @client = client
 
         # Make context available to Tool instances during tool execution
         previous_context = Thread.current[:ruby_llm_agents_caller_context]
@@ -891,27 +892,57 @@ module RubyLLM
 
       # Captures response metadata to the context
       #
-      # @param response [RubyLLM::Message] The response
+      # When a tool returns RubyLLM::Tool::Halt, the response is a Halt
+      # instance with no token metadata. In that case we pull metadata from
+      # the last assistant message in the client's history.
+      #
+      # @param response [RubyLLM::Message, RubyLLM::Tool::Halt] The response
       # @param context [Pipeline::Context] The context
       def capture_response(response, context)
-        context.input_tokens = response.input_tokens
-        context.output_tokens = response.output_tokens
-        context.model_used = response.model_id || model
-        # finish_reason may not be available on all RubyLLM::Message versions
-        context.finish_reason = response.respond_to?(:finish_reason) ? response.finish_reason : nil
+        is_halt = response.is_a?(RubyLLM::Tool::Halt)
+        metadata = is_halt ? last_assistant_message_from_client : response
+
+        if metadata
+          context.input_tokens = metadata.input_tokens if metadata.respond_to?(:input_tokens)
+          context.output_tokens = metadata.output_tokens if metadata.respond_to?(:output_tokens)
+          context.model_used = (metadata.respond_to?(:model_id) && metadata.model_id) || model
+
+          # Capture Anthropic prompt caching metrics
+          if metadata.respond_to?(:cached_tokens) && metadata.cached_tokens&.positive?
+            context[:cached_tokens] = metadata.cached_tokens
+          end
+          if metadata.respond_to?(:cache_creation_tokens) && metadata.cache_creation_tokens&.positive?
+            context[:cache_creation_tokens] = metadata.cache_creation_tokens
+          end
+        else
+          context.model_used = model
+        end
+
+        context.finish_reason = if is_halt
+          "halt"
+        elsif response.respond_to?(:finish_reason)
+          response.finish_reason
+        end
 
         # Store tracked tool calls in context for instrumentation
         context[:tool_calls] = @tracked_tool_calls if @tracked_tool_calls.any?
 
-        # Capture Anthropic prompt caching metrics
-        if response.respond_to?(:cached_tokens) && response.cached_tokens&.positive?
-          context[:cached_tokens] = response.cached_tokens
-        end
-        if response.respond_to?(:cache_creation_tokens) && response.cache_creation_tokens&.positive?
-          context[:cache_creation_tokens] = response.cache_creation_tokens
-        end
+        calculate_costs(metadata, context) if metadata && context.input_tokens
+      end
 
-        calculate_costs(response, context) if context.input_tokens
+      # Finds the most recent assistant message with usage metadata in
+      # the active client's history. Used to recover token/model metadata
+      # when the LLM call short-circuits via Tool::Halt.
+      #
+      # @return [RubyLLM::Message, nil]
+      def last_assistant_message_from_client
+        messages = @client&.messages
+        return nil unless messages
+
+        messages.reverse_each.find do |m|
+          m.respond_to?(:role) && m.role == :assistant &&
+            m.respond_to?(:input_tokens) && m.input_tokens
+        end
       end
 
       # Calculates costs for the response.

--- a/spec/lib/base_agent_execution_spec.rb
+++ b/spec/lib/base_agent_execution_spec.rb
@@ -418,6 +418,44 @@ RSpec.describe RubyLLM::Agents::BaseAgent, "execution methods" do
 
       expect(context.finish_reason).to eq("stop")
     end
+
+    context "when response is a RubyLLM::Tool::Halt" do
+      let(:halt) { RubyLLM::Tool::Halt.new("stopped via halt") }
+
+      it "does not raise NoMethodError on input_tokens" do
+        expect {
+          agent.send(:capture_response, halt, context)
+        }.not_to raise_error
+      end
+
+      it "recovers token metadata from the last assistant message in the client" do
+        prior_assistant = build_real_response(
+          content: "previous",
+          input_tokens: 42,
+          output_tokens: 7,
+          model_id: "gpt-4o"
+        )
+        client = instance_double(RubyLLM::Chat, messages: [prior_assistant])
+        agent.instance_variable_set(:@client, client)
+
+        agent.send(:capture_response, halt, context)
+
+        expect(context.input_tokens).to eq(42)
+        expect(context.output_tokens).to eq(7)
+        expect(context.model_used).to eq("gpt-4o")
+        expect(context.finish_reason).to eq("halt")
+      end
+
+      it "falls back to the configured model when no assistant message is available" do
+        client = instance_double(RubyLLM::Chat, messages: [])
+        agent.instance_variable_set(:@client, client)
+
+        agent.send(:capture_response, halt, context)
+
+        expect(context.model_used).to eq("gpt-4o")
+        expect(context.finish_reason).to eq("halt")
+      end
+    end
   end
 
   describe "#calculate_costs" do


### PR DESCRIPTION
## Summary

- Fixes #30. ruby_llm 1.14 short-circuits `Chat#handle_tool_calls` and returns `RubyLLM::Tool::Halt` (not a `Message`) from `chat.ask`/`complete` when a tool calls `halt`. `BaseAgent#capture_response` then crashed on `response.input_tokens` because `Tool::Halt` only exposes `#content` and `#to_s`.
- Detect `Tool::Halt` in `capture_response` and recover token / model metadata from the last assistant message in the client's history (per the approach suggested upstream in crmne/ruby_llm#436). Set `context.finish_reason = "halt"` so executions are recorded with a meaningful state, and fall back to the configured `model` when no prior assistant message has metadata.
- Cache the chat client as `@client` in `execute` so `capture_response` can reach the message history without changing its signature.

## Test plan

- [x] New regression specs in `spec/lib/base_agent_execution_spec.rb` covering: the original NoMethodError no longer raises, metadata is recovered from the last assistant message, and the no-history path falls back to the configured model with `finish_reason = "halt"`.
- [x] `bundle exec rspec` — 4670 examples, 0 failures.
- [x] `bundle exec standardrb` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)