### PR TITLE
Fix token usage accounting across tool loops and on errors

### DIFF
--- a/lib/ruby_llm/agents/base_agent.rb
+++ b/lib/ruby_llm/agents/base_agent.rb
@@ -831,10 +831,19 @@ module RubyLLM
       # (user, then assistant) before calling complete, so the model
       # continues from the prefill. Otherwise, uses the standard .ask flow.
       #
+      # The client history is baselined before the call so usage accounting
+      # can tell which assistant responses this attempt appends (see
+      # #billed_messages_this_attempt). When the call raises after one or
+      # more responses completed — e.g. a tool error inside a tool loop —
+      # the usage billed up to that point is recovered onto the context
+      # before the error propagates, instead of being discarded.
+      #
       # @param client [RubyLLM::Chat] The configured client
       # @param context [Pipeline::Context] The execution context
       # @return [RubyLLM::Message] The response
       def execute_llm_call(client, context)
+        @usage_history_baseline = history_size(client)
+
         timeout = self.class.timeout
         prefill = resolved_assistant_prefill
 
@@ -849,6 +858,9 @@ module RubyLLM
             client.ask(user_prompt, **ask_opts)
           end
         end
+      rescue
+        recover_usage_from_history(context)
+        raise
       end
 
       # Executes with assistant prefill
@@ -955,6 +967,11 @@ module RubyLLM
         context[:tool_calls] = @tracked_tool_calls if @tracked_tool_calls.any?
 
         calculate_costs(metadata, context) if metadata && context.input_tokens
+
+        # A multi-round tool loop bills every round, not just the final
+        # response captured above. Sum usage across the assistant responses
+        # this attempt appended so tokens and costs reflect the real spend.
+        accumulate_attempt_usage(context)
       end
 
       # Finds the most recent assistant message with usage metadata in
@@ -970,6 +987,86 @@ module RubyLLM
           m.respond_to?(:role) && m.role == :assistant &&
             m.respond_to?(:input_tokens) && m.input_tokens
         end
+      end
+
+      # Recovers the usage billed by this attempt when the LLM call raised
+      # before #capture_response could run.
+      #
+      # Runs #capture_response on the last billed response (the same pattern
+      # Tool::Halt recovery uses); accumulation then replaces its
+      # single-response numbers with the attempt's sums. Best-effort:
+      # recovery must never mask the original failure.
+      #
+      # @param context [Pipeline::Context] The execution context
+      def recover_usage_from_history(context)
+        recovered = billed_messages_this_attempt.last
+        capture_response(recovered, context) if recovered
+      rescue => e
+        log_cost_warning("recover_usage_from_history", e)
+      end
+
+      # Replaces the final response's usage with the sums across every
+      # assistant response this attempt appended to the client history.
+      #
+      # A tool loop bills one request per round, so the final response alone
+      # undercounts the real spend; summing the history reflects what the
+      # provider actually charged. The last request's own usage is stashed
+      # in metadata (the prompt size of the final request is the current
+      # context fill), and costs are recalculated from the sums.
+      #
+      # Retries and fallbacks re-baseline per attempt (see
+      # #execute_llm_call), so the numbers always describe the last attempt
+      # — the billed one — never a cross-attempt double count.
+      #
+      # No-op when the history is unreadable or nothing was appended; the
+      # single-response numbers from #capture_response then stand.
+      #
+      # @param context [Pipeline::Context] The execution context
+      def accumulate_attempt_usage(context)
+        billed = billed_messages_this_attempt
+        return if billed.empty?
+
+        last = billed.last
+        context.input_tokens = billed.sum { |message| message.input_tokens.to_i }
+        context.output_tokens = billed.sum { |message| message.output_tokens.to_i }
+        context[:llm_usage] = {
+          "requests" => billed.size,
+          "last_input_tokens" => last.input_tokens.to_i,
+          "last_output_tokens" => last.output_tokens.to_i
+        }
+        calculate_costs(last, context)
+      rescue => e
+        log_cost_warning("accumulate_attempt_usage", e)
+      end
+
+      # Assistant messages with usage appended to the client history after
+      # the baseline captured by #execute_llm_call — the responses this
+      # attempt was billed for.
+      #
+      # Conversation history (the messages option) is seeded into the client
+      # before the call, so only post-baseline entries are eligible;
+      # otherwise a failed attempt would bill a previous turn's usage.
+      #
+      # @return [Array] Billed assistant messages, empty when unknown
+      def billed_messages_this_attempt
+        baseline = @usage_history_baseline
+        return [] unless baseline
+
+        Array(@client&.messages).drop(baseline).select do |message|
+          message.respond_to?(:role) && message.role == :assistant &&
+            message.respond_to?(:input_tokens) && message.input_tokens
+        end
+      end
+
+      # Number of messages in the client history, or nil when it is
+      # unreadable — usage recovery/accumulation are then skipped.
+      #
+      # @param client [RubyLLM::Chat] The configured client
+      # @return [Integer, nil]
+      def history_size(client)
+        Array(client&.messages).size
+      rescue
+        nil
       end
 
       # Calculates costs for the response.

--- a/spec/lib/base_agent_usage_spec.rb
+++ b/spec/lib/base_agent_usage_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubyLLM::Agents::BaseAgent, "usage accounting across tool loops" do
+  let(:tool_error) { Class.new(StandardError) }
+
+  let(:agent_class) do
+    Class.new(described_class) do
+      def self.name
+        "UsageAccountingAgent"
+      end
+
+      model "gpt-4o"
+
+      def user_prompt
+        "open Instagram"
+      end
+    end
+  end
+
+  let(:agent) { agent_class.new }
+  let(:context) do
+    RubyLLM::Agents::Pipeline::Context.new(
+      input: {},
+      agent_class: agent_class,
+      agent_instance: agent
+    )
+  end
+
+  before do
+    stub_agent_configuration
+  end
+
+  def assistant(input:, output:, model: "gpt-4o")
+    build_real_response(content: "working", input_tokens: input, output_tokens: output, model_id: model)
+  end
+
+  def user_message(content = "tool result")
+    RubyLLM::Message.new(role: :user, content: content)
+  end
+
+  # Mirrors a real chat client: `seeded` transcript rows exist before ask;
+  # `appended` rows land in the history during the tool loop. When `error`
+  # is nil the ask succeeds and returns the last appended message.
+  def build_looping_client(appended, seeded: [], error: nil)
+    history = seeded.dup
+    client = double("RubyLLM::Chat")
+    allow(client).to receive(:with_temperature).and_return(client)
+    allow(client).to receive(:with_instructions).and_return(client)
+    allow(client).to receive(:with_schema).and_return(client)
+    allow(client).to receive(:with_tools).and_return(client)
+    allow(client).to receive(:with_thinking).and_return(client)
+    allow(client).to receive(:on_tool_call).and_return(client)
+    allow(client).to receive(:on_tool_result).and_return(client)
+    allow(client).to receive(:messages) { history }
+    allow(client).to receive(:ask) do
+      history.concat(appended)
+      raise error if error
+
+      appended.last
+    end
+    agent.instance_variable_set(:@client, client)
+    client
+  end
+
+  describe "#execute_llm_call failure path" do
+    it "sums usage across the tool loop when ask raises mid-loop" do
+      client = build_looping_client(
+        [
+          assistant(input: 100, output: 20),
+          user_message,
+          assistant(input: 200, output: 30)
+        ],
+        error: tool_error.new("tool timed out")
+      )
+
+      expect {
+        agent.send(:execute_llm_call, client, context)
+      }.to raise_error(tool_error, "tool timed out")
+
+      expect(context.input_tokens).to eq(300)
+      expect(context.output_tokens).to eq(50)
+      expect(context.model_used).to eq("gpt-4o")
+      expect(context[:llm_usage]).to eq(
+        "requests" => 2,
+        "last_input_tokens" => 200,
+        "last_output_tokens" => 30
+      )
+    end
+
+    it "prices the summed usage through cost calculation" do
+      pricing = build_model_info_with_pricing(input_price: 2.0, output_price: 10.0)
+      allow(agent).to receive(:find_model_info).and_return(pricing)
+      client = build_looping_client(
+        [assistant(input: 600_000, output: 300_000), assistant(input: 400_000, output: 200_000)],
+        error: tool_error.new("tool timed out")
+      )
+
+      expect { agent.send(:execute_llm_call, client, context) }.to raise_error(tool_error)
+
+      expect(context.input_cost).to eq(2.0)
+      expect(context.output_cost).to eq(5.0)
+      expect(context.total_cost).to eq(7.0)
+    end
+
+    it "recovers usage on cooperative cancellation inside the tool loop" do
+      client = build_looping_client(
+        [assistant(input: 50, output: 10)],
+        error: RubyLLM::Agents::CancelledError.new("cancel requested")
+      )
+
+      expect {
+        agent.send(:execute_llm_call, client, context)
+      }.to raise_error(RubyLLM::Agents::CancelledError)
+
+      expect(context.input_tokens).to eq(50)
+      expect(context.output_tokens).to eq(10)
+    end
+
+    it "ignores assistant history seeded before the call (transcript replay)" do
+      client = build_looping_client(
+        [user_message],
+        seeded: [assistant(input: 999, output: 99)],
+        error: tool_error.new("tool timed out")
+      )
+
+      expect { agent.send(:execute_llm_call, client, context) }.to raise_error(tool_error)
+
+      expect(context.input_tokens.to_i).to eq(0)
+      expect(context.output_tokens.to_i).to eq(0)
+    end
+
+    it "leaves context untouched when the failure precedes any completed response" do
+      client = build_looping_client([user_message], error: tool_error.new("tool timed out"))
+
+      expect { agent.send(:execute_llm_call, client, context) }.to raise_error(tool_error)
+
+      expect(context.input_tokens.to_i).to eq(0)
+      expect(context.output_tokens.to_i).to eq(0)
+    end
+
+    it "never masks the original error when recovery itself fails" do
+      client = double("RubyLLM::Chat")
+      allow(client).to receive(:messages).and_raise(RuntimeError, "history unavailable")
+      allow(client).to receive(:ask).and_raise(tool_error, "original")
+      agent.instance_variable_set(:@client, client)
+
+      expect {
+        agent.send(:execute_llm_call, client, context)
+      }.to raise_error(tool_error, "original")
+    end
+  end
+
+  describe "#capture_response" do
+    it "sums usage across the tool loop on the successful path too" do
+      client = build_looping_client(
+        [
+          assistant(input: 1_000, output: 50),
+          user_message,
+          assistant(input: 2_000, output: 40)
+        ]
+      )
+
+      response = agent.send(:execute_llm_call, client, context)
+      agent.send(:capture_response, response, context)
+
+      expect(context.input_tokens).to eq(3_000)
+      expect(context.output_tokens).to eq(90)
+      expect(context[:llm_usage]).to eq(
+        "requests" => 2,
+        "last_input_tokens" => 2_000,
+        "last_output_tokens" => 40
+      )
+    end
+
+    it "keeps the single-response numbers when the history is unavailable" do
+      response = assistant(input: 100, output: 50)
+      client = double("RubyLLM::Chat")
+      allow(client).to receive(:messages).and_return([])
+      allow(client).to receive(:ask).and_return(response)
+      agent.instance_variable_set(:@client, client)
+
+      agent.send(:execute_llm_call, client, context)
+      agent.send(:capture_response, response, context)
+
+      expect(context.input_tokens).to eq(100)
+      expect(context.output_tokens).to eq(50)
+      expect(context[:llm_usage]).to be_nil
+    end
+
+    it "re-baselines per attempt so a retry overwrites instead of double counting" do
+      failing = build_looping_client(
+        [assistant(input: 200, output: 30)],
+        error: tool_error.new("tool timed out")
+      )
+      expect { agent.send(:execute_llm_call, failing, context) }.to raise_error(tool_error)
+      expect(context.input_tokens).to eq(200)
+
+      retrying = build_looping_client([assistant(input: 10, output: 5)])
+      response = agent.send(:execute_llm_call, retrying, context)
+      agent.send(:capture_response, response, context)
+
+      expect(context.input_tokens).to eq(10)
+      expect(context.output_tokens).to eq(5)
+      expect(context[:llm_usage]).to eq(
+        "requests" => 1,
+        "last_input_tokens" => 10,
+        "last_output_tokens" => 5
+      )
+    end
+  end
+
+  describe "#execute" do
+    it "sums usage across the loop through the full execution path" do
+      client = build_looping_client(
+        [
+          assistant(input: 100, output: 10),
+          user_message,
+          assistant(input: 200, output: 20)
+        ]
+      )
+      stub_ruby_llm_chat(client)
+
+      agent.send(:execute, context)
+
+      expect(context.input_tokens).to eq(300)
+      expect(context.output_tokens).to eq(30)
+      expect(context.output).to be_a(RubyLLM::Agents::Result)
+      expect(context.output.content).to eq("working")
+    end
+  end
+end


### PR DESCRIPTION
## Defect

Token usage accounting in `BaseAgent` is wrong in two related ways whenever an agent run involves more than a single provider request (a tool loop), and whenever it fails:

1. **Undercounting on success.** `capture_response` records usage from the *final* response only. A tool loop bills one request per round, so a run with N rounds records roughly 1/N of the real spend in `input_tokens` / `output_tokens` / costs on the execution row.

2. **Total loss on failure.** Usage is only captured after `execute_llm_call` returns. If `ask` raises mid-loop (e.g. a tool error, a provider error on round 3, or a timeout), `capture_response` never runs and the execution persists 0 tokens / $0 — even though every completed round was billed by the provider.

## Reproduction

```ruby
class LoopAgent < RubyLLM::Agents::BaseAgent
  model "gpt-4o"
  def user_prompt = "do the thing"
end

agent = LoopAgent.new
context = RubyLLM::Agents::Pipeline::Context.new(input: {}, agent_class: LoopAgent, agent_instance: agent)

# A chat client whose ask appends two billable assistant responses
# (round 1 + round 2 of a tool loop) and then raises from the tool.
client = <chat double; messages grows by 2 assistant messages with usage, ask raises>
agent.instance_variable_set(:@client, client)

agent.send(:execute_llm_call, client, context) # raises
context.input_tokens  # => 0 (expected: sum of both rounds)
context.total_cost    # => 0.0
```

The success path has the mirror-image problem: with rounds of 1000+2000 input tokens, `context.input_tokens` ends up `2000` instead of `3000`.

## Fix

One seam, in `BaseAgent`:

- `execute_llm_call` baselines the client history size at call start. Conversation replay (the `messages` option) seeds prior turns into the client, so only assistant messages appended *after* the baseline are this attempt's billable usage.
- On exception, `recover_usage_from_history` runs `capture_response` on the last billed response (the same pattern `Tool::Halt` recovery uses) before re-raising — the original error always propagates, and recovery itself is best-effort.
- `capture_response` now calls `accumulate_attempt_usage`, which sums input/output tokens across the attempt's appended assistant responses, stashes the last request's own usage in `context[:llm_usage]` metadata (`requests`, `last_input_tokens`, `last_output_tokens` — the prompt size of the final request is the current context fill), and recalculates costs from the sums.

Retries/fallbacks re-baseline per attempt (a fresh client per `execute`), so persisted numbers always describe the last attempt — the billed one — never a cross-attempt double count. Single-request runs are unchanged: the sum of one appended assistant message equals the response's own usage, and when the history is unreadable the pre-existing single-response numbers stand.

## Tests

New `spec/lib/base_agent_usage_spec.rb` (10 examples):

- sums usage across the tool loop when `ask` raises mid-loop, including model id and `llm_usage` metadata
- prices the summed usage through `calculate_costs`
- recovers usage on cooperative cancellation (`CancelledError`) inside the loop
- ignores assistant history seeded before the call (transcript replay)
- leaves context untouched when the failure precedes any completed response
- never masks the original error when recovery itself fails
- sums usage on the successful path
- keeps single-response numbers when the history is unavailable
- re-baselines per attempt (retry overwrites instead of double counting)
- sums through the full `#execute` path

Full suite: 4906 examples, 0 failures (Ruby 3.3.6). `standardrb` clean on changed files.
