### PR TITLE
Prevent completion from overwriting terminal execution rows

### DIFF
--- a/lib/ruby_llm/agents/pipeline/middleware/instrumentation.rb
+++ b/lib/ruby_llm/agents/pipeline/middleware/instrumentation.rb
@@ -172,6 +172,12 @@ module RubyLLM
           # Falls back to creating a new record if the initial record is nil.
           # Errors are re-raised to allow the ensure block to handle them.
           #
+          # The record is locked and reloaded before updating: the instance
+          # held here was created when the pipeline started and may be stale —
+          # a concurrent transition (e.g. operator cancellation or a timeout
+          # sweep) can have written a terminal status in the meantime, and the
+          # completion must not overwrite it.
+          #
           # @param execution [Execution, nil] The execution record to update
           # @param context [Context] The execution context
           # @param status [String] Final status ("success", "error", "timeout")
@@ -188,13 +194,38 @@ module RubyLLM
             end
 
             update_data = build_completion_data(context, status)
-            execution.update!(update_data)
+            return unless complete_running_execution(execution, update_data)
 
             # Save detail data (prompts, responses, tool calls, etc.)
             save_execution_details(execution, context, status)
           rescue => e
             error("Failed to complete execution record: #{e.message}", context)
             raise # Re-raise for ensure block to handle via mark_execution_failed!
+          end
+
+          # Applies the completion update unless the execution already left
+          # "running" state.
+          #
+          # Locks the row and reloads it, so the status check and the update
+          # are atomic with respect to concurrent status transitions: whichever
+          # side wins the row lock first keeps the row. A completion that finds
+          # a terminal status is dropped instead of overwriting it.
+          #
+          # @param execution [Execution] The execution record to update
+          # @param update_data [Hash] The completion attributes
+          # @return [Boolean] Whether the completion update was applied
+          def complete_running_execution(execution, update_data)
+            return execution.update!(update_data) unless execution.persisted?
+
+            execution.with_lock do
+              if execution.status == "running"
+                execution.update!(update_data)
+                true
+              else
+                debug("Skipped completion for execution #{execution.id}: already #{execution.status}")
+                false
+              end
+            end
           end
 
           # Emergency fallback to mark execution as failed

--- a/spec/lib/pipeline/middleware/instrumentation_spec.rb
+++ b/spec/lib/pipeline/middleware/instrumentation_spec.rb
@@ -277,6 +277,62 @@ RSpec.describe RubyLLM::Agents::Pipeline::Middleware::Instrumentation do
         end
       end
 
+      describe "concurrent status transitions" do
+        it "does not overwrite a terminal status written while the pipeline ran" do
+          context = build_context
+
+          allow(app).to receive(:call) do |ctx|
+            # A concurrent transition (e.g. a timeout sweep or operator
+            # cancellation) lands while the pipeline is still running
+            RubyLLM::Agents::Execution.where(id: ctx.execution_id).update_all(
+              status: "timeout",
+              error_class: "Timeout::Error",
+              completed_at: Time.current
+            )
+            ctx.output = "result"
+            ctx
+          end
+
+          middleware.call(context)
+
+          execution = RubyLLM::Agents::Execution.find(context.execution_id)
+          expect(execution.status).to eq("timeout")
+          expect(execution.error_class).to eq("Timeout::Error")
+        end
+
+        it "skips the completion when the held instance is stale and the row is already terminal" do
+          stale = create(:execution, :running, agent_type: "TestAgent", model_id: "test-model")
+          # The row transitioned behind the instance's back
+          RubyLLM::Agents::Execution.where(id: stale.id)
+            .update_all(status: "error", error_class: "StandardError")
+
+          context = build_context
+          context.completed_at = Time.current
+          context.input_tokens = 999
+
+          middleware.send(:complete_execution, stale, context, status: "success")
+
+          stale.reload
+          expect(stale.status).to eq("error")
+          expect(stale.error_class).to eq("StandardError")
+          expect(stale.input_tokens).to eq(100)
+        end
+
+        it "still updates the row when it is still running" do
+          running = create(:execution, :running, agent_type: "TestAgent", model_id: "test-model")
+
+          context = build_context
+          context.completed_at = Time.current
+          context.input_tokens = 999
+
+          middleware.send(:complete_execution, running, context, status: "success")
+
+          running.reload
+          expect(running.status).to eq("success")
+          expect(running.input_tokens).to eq(999)
+        end
+      end
+
       it "truncates long error messages" do
         context = build_context
         long_message = "x" * 2000


### PR DESCRIPTION
## Defect

`Instrumentation#complete_execution(execution, context, status:)` completes the run through the `Execution` instance that was created when the pipeline started. Between the "running" row insert and the completion update — the entire LLM call, tool loop, and retries — that in-memory instance goes stale, and `execution.update!(update_data)` unconditionally overwrites the row's status (plus tokens, costs, `completed_at`, etc.).

If anything else transitions the row to a terminal state while the pipeline is still running — a timeout sweep marking a stuck execution `timeout`, an operator cancellation, a monitor writing `error` — the pipeline's completion blindly overwrites that terminal status with `success`/`error` (in whichever order they interleave). The last writer wins, and the row ends up claiming a run succeeded when it was, say, timed out minutes ago.

## Reproduction

```ruby
execution = RubyLLM::Agents::Execution.find(context.execution_id) # status "running"

# meanwhile, outside the pipeline (timeout sweep / cancellation):
RubyLLM::Agents::Execution.where(id: execution.id)
  .update_all(status: "timeout", error_class: "Timeout::Error", completed_at: Time.current)

# pipeline then finishes and completes through its stale instance:
middleware.send(:complete_execution, execution, context, status: "success")

execution.reload.status # => "success" — the terminal timeout was overwritten
```

The same race exists in the other direction (`status: "error"` completion overwriting a terminal state written concurrently).

## Fix

Inside `complete_execution`, apply the update only while the row is still `running`, atomically:

- lock and reload the row (`execution.with_lock`), so the status check and the update are atomic with respect to concurrent writers — whichever side wins the row lock first keeps the row;
- skip the completion (and the detail save) when the locked row already shows a terminal status, logging a debug breadcrumb;
- non-persisted records keep the previous plain `update!` behavior.

No change to the happy path: a row that is still `running` is updated exactly as before, and the `ensure`/`mark_execution_failed!` fallback is untouched.

## Tests

New `concurrent status transitions` examples in `spec/lib/pipeline/middleware/instrumentation_spec.rb`:

- a terminal status written concurrently while the pipeline runs survives completion (full middleware `#call`)
- a stale held instance no longer overwrites a terminal row (status, error class, and metrics untouched)
- a still-`running` row is updated normally (control)

Both defect-pinning specs fail on `main` (the row flips to `"success"`) and pass with the fix. Full suite: 4899 examples, 0 failures (Ruby 3.3.6). `standardrb` clean on changed files.
