### PR TITLE
Preserve tracker tags when an execution completes

### DIFF
--- a/lib/ruby_llm/agents/pipeline/middleware/instrumentation.rb
+++ b/lib/ruby_llm/agents/pipeline/middleware/instrumentation.rb
@@ -429,6 +429,13 @@ module RubyLLM
               data[:attempts_count] = context[:reliability_attempts].size
             end
 
+            # Carry the tracker request_id/tags that
+            # build_running_execution_data injected through the metadata
+            # rebuild — otherwise a completed execution loses them. Only
+            # merge into a rebuild that actually produced metadata: when
+            # none did, the running record's metadata stays untouched.
+            inject_tracker_data(context, data) if data[:metadata]
+
             data
           end
 

--- a/spec/lib/pipeline/middleware/instrumentation_spec.rb
+++ b/spec/lib/pipeline/middleware/instrumentation_spec.rb
@@ -605,6 +605,71 @@ RSpec.describe RubyLLM::Agents::Pipeline::Middleware::Instrumentation do
     end
   end
 
+  describe "tracker tags on completion" do
+    before do
+      RubyLLM::Agents.configuration.track_embeddings = true
+      RubyLLM::Agents.configuration.multi_tenancy_enabled = false
+    end
+
+    let(:tracked_agent) do
+      Object.new.tap do |agent|
+        agent.instance_variable_set(:@_track_tags, {"device_id" => "7", "chat_id" => "3"})
+      end
+    end
+
+    it "keeps tracker tags when the completion rebuild produces metadata" do
+      context = build_context(agent_instance: tracked_agent)
+
+      allow(app).to receive(:call) do |ctx|
+        ctx[:llm_request_count] = 1
+        ctx.output = "result"
+        ctx
+      end
+
+      middleware.call(context)
+
+      execution = RubyLLM::Agents::Execution.last
+      expect(execution.metadata["tags"]).to eq("device_id" => "7", "chat_id" => "3")
+      expect(execution.metadata["llm_request_count"]).to eq(1)
+    end
+
+    it "keeps tracker tags on failed executions" do
+      context = build_context(agent_instance: tracked_agent)
+
+      allow(app).to receive(:call).and_raise(StandardError, "boom")
+
+      expect { middleware.call(context) }.to raise_error(StandardError)
+
+      execution = RubyLLM::Agents::Execution.last
+      expect(execution.metadata["tags"]).to eq("device_id" => "7", "chat_id" => "3")
+    end
+
+    it "does not add tags when no tracker was active" do
+      context = build_context(agent_instance: Object.new)
+
+      allow(app).to receive(:call) do |ctx|
+        ctx[:llm_request_count] = 1
+        ctx.output = "result"
+        ctx
+      end
+
+      middleware.call(context)
+
+      execution = RubyLLM::Agents::Execution.last
+      expect(execution.metadata).not_to have_key("tags")
+      expect(execution.metadata["llm_request_count"]).to eq(1)
+    end
+
+    it "leaves completion metadata unset when the rebuild is empty, preserving the running record's metadata" do
+      context = build_context(agent_instance: tracked_agent)
+      context.completed_at = Time.current
+
+      data = middleware.send(:build_completion_data, context, "success")
+
+      expect(data).not_to have_key(:metadata)
+    end
+  end
+
   describe "agent metadata merging" do
     before do
       RubyLLM::Agents.reset_configuration!


### PR DESCRIPTION
## Defect

`Instrumentation#build_running_execution_data` injects the active tracker's `request_id` and `tags` (via `inject_tracker_data`) into the execution's metadata when the "running" row is created. But when the run completes, `build_completion_data` *rebuilds* `metadata` from agent metadata + context metadata and never carries the tracker fields over. So whenever the completion rebuild produces any metadata at all — which it does on essentially every successful LLM run, since request timing/count land in context metadata — the `update!` replaces the whole `metadata` column and the `tags` correlation written at start is gone.

Error runs keep their tags only by accident: their rebuild usually produces no metadata, so the column is left untouched.

## Reproduction

```ruby
middleware = RubyLLM::Agents::Pipeline::Middleware::Instrumentation.new(app, MyAgent)

RubyLLM::Agents.track(tags: {feature: "voice-chat", session_id: "sess_1"}) do
  middleware.call(context) # successful run that records llm_request_count in metadata
end

execution = RubyLLM::Agents::Execution.last
execution.metadata["llm_request_count"] # => 1
execution.metadata["tags"]              # => nil (expected: {"feature" => "voice-chat", "session_id" => "sess_1"})
```

## Fix

At the end of `build_completion_data`, call the existing `inject_tracker_data(context, data)` — the same helper `build_running_execution_data` uses — but only when the rebuild actually produced metadata (`if data[:metadata]`). The guard keeps the no-metadata case on the previous behavior: `data` carries no `metadata` key, the `update!` leaves the column alone, and the running record's metadata (tags included) is preserved. This also avoids replacing the column with a tags-only hash, so other keys written at start (e.g. `replay_source_id`) can never be clobbered by the completion.

## Tests

New `tracker tags on completion` examples in `spec/lib/pipeline/middleware/instrumentation_spec.rb`:

- successful run keeps tracker tags alongside rebuilt metadata (fails on `main` — tags are dropped)
- failed executions keep tracker tags (pins the existing behavior)
- no tags are added when no tracker was active
- an empty rebuild leaves completion metadata unset, preserving the running record's metadata

Full suite: 4900 examples, 0 failures (Ruby 3.3.6). `standardrb` clean on changed files.
