### PR TITLE
fix(cost): record cache reads and bill them at the cached rate

### DIFF
--- a/lib/ruby_llm/agents/base_agent.rb
+++ b/lib/ruby_llm/agents/base_agent.rb
@@ -934,11 +934,18 @@ module RubyLLM
           context.output_tokens = metadata.output_tokens if metadata.respond_to?(:output_tokens)
           context.model_used = (metadata.respond_to?(:model_id) && metadata.model_id) || model
 
-          # Capture Anthropic prompt caching metrics
+          # Prompt-cache metrics. Every provider that reports them lands here —
+          # not just Anthropic: OpenAI caches automatically with no opt-in, so
+          # these are populated on ordinary calls with a long stable prefix.
+          # Kept on the context's own accessors (and mirrored into metadata for
+          # backward compatibility) because #build_result and #calculate_costs
+          # both read them back.
           if metadata.respond_to?(:cached_tokens) && metadata.cached_tokens&.positive?
+            context.cached_tokens = metadata.cached_tokens
             context[:cached_tokens] = metadata.cached_tokens
           end
           if metadata.respond_to?(:cache_creation_tokens) && metadata.cache_creation_tokens&.positive?
+            context.cache_creation_tokens = metadata.cache_creation_tokens
             context[:cache_creation_tokens] = metadata.cache_creation_tokens
           end
         else
@@ -1001,7 +1008,7 @@ module RubyLLM
         input_price = model_info.pricing&.text_tokens&.input || 0
         output_price = model_info.pricing&.text_tokens&.output || 0
 
-        context.input_cost = (input_tokens / 1_000_000.0) * input_price
+        context.input_cost = input_cost_for(input_tokens, input_price, model_info, context)
 
         # Price cache/reasoning extras first so we know whether reasoning was
         # actually billed at the reasoning rate. Only then exclude those tokens
@@ -1012,6 +1019,75 @@ module RubyLLM
         context.output_cost = ([billable_output, 0].max / 1_000_000.0) * output_price
 
         context.total_cost = (context.input_cost + context.output_cost + extra).round(6)
+      end
+
+      # Input charge, with cache reads billed at the cached rate rather than the
+      # full one.
+      #
+      # Providers disagree on whether the reported input_tokens ALREADY contains
+      # the cache reads, and the difference decides who has a bug:
+      #
+      #   OpenAI    prompt_tokens       INCLUDES prompt_tokens_details.cached_tokens
+      #   Gemini    promptTokenCount    INCLUDES cachedContentTokenCount
+      #   Anthropic input_tokens        EXCLUDES cache_read_input_tokens
+      #
+      # On Anthropic the cache read is genuinely additive, so charging the full
+      # input_tokens at full rate and letting #extra_token_costs add cache_read
+      # on top is already correct — that path is left untouched.
+      #
+      # On OpenAI and Gemini the cached tokens are sitting inside input_tokens,
+      # so charging them at the full rate overstates spend by 2-3x on exactly
+      # the workload caching exists for (a long stable system prompt replayed
+      # every turn) — and would double-charge outright once the provider also
+      # reports a cache_read cost component. Those get split here instead.
+      #
+      # Falls back to the full input rate whenever the split can't be made
+      # safely (no cache reported, or no cached price in the registry), so an
+      # unknown model is never under-billed.
+      #
+      # @return [Float] The input cost in USD
+      def input_cost_for(input_tokens, input_price, model_info, context)
+        full_rate_charge = (input_tokens / 1_000_000.0) * input_price
+
+        cached_tokens = context.cached_tokens.to_i
+        return full_rate_charge unless cached_tokens.positive?
+        return full_rate_charge unless cached_tokens_included_in_input?(model_info)
+
+        cached_price = cached_input_price(model_info)
+        return full_rate_charge unless cached_price
+
+        # Tells extra_token_costs not to charge these same reads a second time.
+        context[:cache_read_priced] = true
+
+        uncached_tokens = [input_tokens - cached_tokens, 0].max
+        (uncached_tokens / 1_000_000.0) * input_price +
+          (cached_tokens / 1_000_000.0) * cached_price
+      end
+
+      # Per-million price for a cache read, or nil when the model registry
+      # doesn't publish one. Pricing shapes vary by source (and are stubbed with
+      # partial doubles in tests), so an absent field degrades to "unknown" —
+      # callers then charge the full input rate rather than guessing a discount.
+      #
+      # @return [Float, nil]
+      def cached_input_price(model_info)
+        tier = model_info.pricing&.text_tokens
+        return nil unless tier.respond_to?(:cached_input)
+
+        tier.cached_input
+      rescue
+        nil
+      end
+
+      # Whether this provider's reported input_tokens already contains the cache
+      # reads. See #input_cost_for for the per-provider breakdown. Anthropic is
+      # the exception; defaulting the unknown case to "included" matches every
+      # other provider RubyLLM supports.
+      #
+      # @return [Boolean]
+      def cached_tokens_included_in_input?(model_info)
+        provider = model_info.respond_to?(:provider) ? model_info.provider.to_s : ""
+        !provider.include?("anthropic")
       end
 
       # Number of reasoning (thinking) tokens that were actually charged at the
@@ -1050,8 +1126,12 @@ module RubyLLM
         cost = response_cost(response, model_info)
         return 0.0 unless cost
 
+        # Skip cache_read when #input_cost_for already billed the cache at the
+        # cached rate — otherwise the same tokens are charged twice (once inside
+        # input_tokens at full rate, once here). Cache WRITES are always extra:
+        # no provider folds them into input_tokens.
         components = {
-          cache_read: cost.cache_read,
+          cache_read: (cost.cache_read unless context[:cache_read_priced]),
           cache_write: cost.cache_write,
           thinking: cost.thinking
         }.compact.reject { |_, value| value.zero? }
@@ -1156,6 +1236,8 @@ module RubyLLM
           agent_class_name: self.class.name,
           input_tokens: context.input_tokens,
           output_tokens: context.output_tokens,
+          cached_tokens: context.cached_tokens,
+          cache_creation_tokens: context.cache_creation_tokens,
           input_cost: context.input_cost,
           output_cost: context.output_cost,
           total_cost: context.total_cost,

--- a/lib/ruby_llm/agents/pipeline/context.rb
+++ b/lib/ruby_llm/agents/pipeline/context.rb
@@ -43,6 +43,11 @@ module RubyLLM
         # Cost tracking
         attr_accessor :input_tokens, :output_tokens, :input_cost, :output_cost, :total_cost
 
+        # Prompt-cache usage. First-class accessors, not metadata keys: these
+        # feed both the persisted execution record and the input-cost split, so
+        # a generic bag entry would be silently droppable (it was).
+        attr_accessor :cached_tokens, :cache_creation_tokens
+
         # Response metadata
         attr_accessor :model_used, :finish_reason, :time_to_first_token_ms
 

--- a/spec/agents/cached_token_pricing_spec.rb
+++ b/spec/agents/cached_token_pricing_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Cache reads are billed at a discount (4x cheaper on OpenAI, 10x on Anthropic).
+# Charging them at the full input rate overstates spend by 2-3x on exactly the
+# workload prompt caching exists for — a long stable system prompt replayed every
+# turn — which is how a production app read its own margin as 31% when it was
+# nearer 67%.
+RSpec.describe "Cached token pricing" do
+  before { stub_agent_configuration(track_executions: false) }
+
+  let(:agent_class) { Class.new(RubyLLM::Agents::Base) { model "gpt-4.1" } }
+  let(:agent) { agent_class.new }
+
+  def pricing(input:, output:, cached:)
+    text_tokens = double("PricingTier", input: input, output: output, cached_input: cached)
+    double("ModelInfo", pricing: double("Pricing", text_tokens: text_tokens))
+  end
+
+  def model_info(provider:, input: 2.0, output: 8.0, cached: 0.5)
+    info = pricing(input: input, output: output, cached: cached)
+    allow(info).to receive(:provider).and_return(provider)
+    allow(info).to receive(:id).and_return("test-model")
+    info
+  end
+
+  def context_with(input_tokens:, output_tokens: 0, cached_tokens: nil)
+    ctx = RubyLLM::Agents::Pipeline::Context.new(input: "hi", agent_class: agent_class)
+    ctx.input_tokens = input_tokens
+    ctx.output_tokens = output_tokens
+    ctx.cached_tokens = cached_tokens
+    ctx
+  end
+
+  # A response that exposes no #cost, matching RubyLLM::Message in 1.14.x —
+  # so extra_token_costs contributes nothing and input_cost is isolated.
+  def response_for(model_id = "gpt-4.1")
+    double("Message", model_id: model_id)
+  end
+
+  def calculate(ctx, info)
+    allow(agent).to receive(:find_model_info).and_return(info)
+    agent.send(:calculate_costs, response_for, ctx)
+    ctx
+  end
+
+  describe "providers whose input_tokens INCLUDE the cache reads (OpenAI, Gemini)" do
+    it "bills the cached portion at the cached rate, not the full rate" do
+      ctx = calculate(context_with(input_tokens: 7112, cached_tokens: 6016), model_info(provider: "openai"))
+
+      # 1096 uncached @ $2/M + 6016 cached @ $0.50/M
+      expect(ctx.input_cost).to be_within(1e-9).of((1096 / 1e6 * 2.0) + (6016 / 1e6 * 0.5))
+    end
+
+    it "is materially cheaper than charging every input token at full rate" do
+      ctx = calculate(context_with(input_tokens: 7112, cached_tokens: 6016), model_info(provider: "openai"))
+
+      naive = 7112 / 1e6 * 2.0
+      expect(ctx.input_cost).to be < naive / 2 # the bug overstated by ~2.7x
+    end
+
+    it "treats Gemini the same way" do
+      ctx = calculate(context_with(input_tokens: 1000, cached_tokens: 800), model_info(provider: "gemini"))
+
+      expect(ctx.input_cost).to be_within(1e-9).of((200 / 1e6 * 2.0) + (800 / 1e6 * 0.5))
+    end
+  end
+
+  describe "Anthropic, whose input_tokens EXCLUDE the cache reads" do
+    # Its reported input_tokens is already net of the cache read, so the cache
+    # is genuinely additive and extra_token_costs prices it. Subtracting here
+    # would bill a prefix that was never in input_tokens to begin with.
+    it "leaves the input charge at the full rate on all reported input tokens" do
+      ctx = calculate(context_with(input_tokens: 1096, cached_tokens: 6016), model_info(provider: "anthropic"))
+
+      expect(ctx.input_cost).to be_within(1e-9).of(1096 / 1e6 * 2.0)
+    end
+
+    it "leaves cache_read for extra_token_costs to charge" do
+      ctx = calculate(context_with(input_tokens: 1096, cached_tokens: 6016), model_info(provider: "anthropic"))
+
+      expect(ctx[:cache_read_priced]).to be_nil
+    end
+  end
+
+  describe "fallbacks" do
+    it "charges everything at the full rate when no cache was reported" do
+      ctx = calculate(context_with(input_tokens: 5000), model_info(provider: "openai"))
+
+      expect(ctx.input_cost).to be_within(1e-9).of(5000 / 1e6 * 2.0)
+    end
+
+    it "never under-bills a model whose registry entry has no cached price" do
+      info = model_info(provider: "openai", cached: nil)
+      ctx = calculate(context_with(input_tokens: 7112, cached_tokens: 6016), info)
+
+      expect(ctx.input_cost).to be_within(1e-9).of(7112 / 1e6 * 2.0)
+    end
+
+    it "does not mark the cache as priced when it fell back to full rate" do
+      info = model_info(provider: "openai", cached: nil)
+      ctx = calculate(context_with(input_tokens: 7112, cached_tokens: 6016), info)
+
+      # extra_token_costs must still be free to add cache_read itself
+      expect(ctx[:cache_read_priced]).to be_nil
+    end
+
+    it "flags the cache as priced so extra_token_costs does not charge it twice" do
+      ctx = calculate(context_with(input_tokens: 7112, cached_tokens: 6016), model_info(provider: "openai"))
+
+      expect(ctx[:cache_read_priced]).to be true
+    end
+  end
+end

--- a/spec/agents/prompt_caching_spec.rb
+++ b/spec/agents/prompt_caching_spec.rb
@@ -246,10 +246,11 @@ RSpec.describe "Anthropic prompt caching" do
       allow(RubyLLM::Models).to receive(:find).and_return(claude_info)
 
       result = klass.call
-      # The result itself doesn't expose cache tokens, but the context metadata does.
-      # We verify via the execution pipeline — the context[:cached_tokens] is set.
-      # Since we disabled track_executions, we verify indirectly through the response capture.
+      # The Result carries the cache metrics through from the response — without
+      # this they were captured onto the context and then silently dropped by
+      # #build_result, landing as 0 in every persisted execution row.
       expect(result).to be_a(RubyLLM::Agents::Result)
+      expect(result.cached_tokens).to eq(1500)
     end
 
     it "captures cache_creation_tokens when present" do
@@ -276,6 +277,7 @@ RSpec.describe "Anthropic prompt caching" do
 
       result = klass.call
       expect(result).to be_a(RubyLLM::Agents::Result)
+      expect(result.cache_creation_tokens).to eq(2000)
     end
   end
 


### PR DESCRIPTION
## Summary

Two bugs, one root: cache metrics were captured and then dropped.

1. **`cached_tokens` never reached the persisted execution.** `capture_response` read `metadata.cached_tokens` into the context's generic metadata bag, but `Pipeline::Context` had no first-class accessor for it and `build_result` never copied it into the Result — so every attempt recorded `cached_tokens: 0`. Context now carries `cached_tokens`/`cache_creation_tokens` as real accessors and `build_result` passes them through.

2. **Cache reads were billed at the full input rate.** `calculate_costs` charged `input_tokens * input_price` unconditionally. Correct on Anthropic (input is reported net of cache reads — that path is untouched), wrong on OpenAI/Gemini whose `prompt_tokens`/`promptTokenCount` *include* cache reads. Cached tokens were charged at ~4x their real price, overstating spend ~2.7x on cached workloads (7112 input with 6016 cached costs $0.0052, not the $0.0142 being recorded). Cache reads are now split out and billed at the provider's cached rate.

## Test plan

- New `spec/agents/cached_token_pricing_spec.rb` covering per-provider billing (Anthropic net vs OpenAI/Gemini gross) and cached-token propagation into the Result
- Updated `spec/agents/prompt_caching_spec.rb`
- `bundle exec rspec` + `standardrb` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)